### PR TITLE
fix(admin): remove x1000 in CO2 equivalents

### DIFF
--- a/admin/src/components/charts/EmissionsReductionsChart.vue
+++ b/admin/src/components/charts/EmissionsReductionsChart.vue
@@ -74,22 +74,22 @@ const textLabels = computed(() => {
     current_emissions: formatNumber(currentEmissions.value / 1000), // convert from kg to tons
     new_emissions: formatNumber(newEmissions.value / 1000),
     cheeseburgers: formatNumber(
-      Math.round(((currentEmissions.value - newEmissions.value) * 1000) / 18.8), // kg to grams ?
+      Math.round((currentEmissions.value - newEmissions.value) / 18.8),
     ),
     vacuum: formatNumber(
-      Math.round(((currentEmissions.value - newEmissions.value) * 1000) / 73.43),
+      Math.round((currentEmissions.value - newEmissions.value) / 73.43),
     ),
     shirt: formatNumber(
-      Math.round(((currentEmissions.value - newEmissions.value) * 1000) / 13.23466),
+      Math.round((currentEmissions.value - newEmissions.value) / 13.23466),
     ),
     laptop: formatNumber(
-      Math.round(((currentEmissions.value - newEmissions.value) * 1000) / 192.62),
+      Math.round((currentEmissions.value - newEmissions.value) / 192.62),
     ),
     email_sent: formatNumber(
-      Math.round(((currentEmissions.value - newEmissions.value) * 1000) / 0.002462),
+      Math.round((currentEmissions.value - newEmissions.value) / 0.002462),
     ),
     visio_hour: formatNumber(
-      Math.round(((currentEmissions.value - newEmissions.value) * 1000) / 0.057063),
+      Math.round((currentEmissions.value - newEmissions.value) / 0.057063),
     ),
   }
 })

--- a/admin/src/components/charts/RecoEmissionsChart.vue
+++ b/admin/src/components/charts/RecoEmissionsChart.vue
@@ -74,22 +74,22 @@ const textLabels = computed(() => {
     current_emissions: formatNumber(currentEmissions.value / 1000),
     new_emissions: formatNumber(newEmissions.value / 1000),
     cheeseburgers: formatNumber(
-      Math.round(((currentEmissions.value - newEmissions.value) * 1000) / 18.8),
+      Math.round((currentEmissions.value - newEmissions.value) / 18.8),
     ),
     vacuum: formatNumber(
-      Math.round(((currentEmissions.value - newEmissions.value) * 1000) / 73.43),
+      Math.round((currentEmissions.value - newEmissions.value) / 73.43),
     ),
     shirt: formatNumber(
-      Math.round(((currentEmissions.value - newEmissions.value) * 1000) / 13.23466),
+      Math.round((currentEmissions.value - newEmissions.value) / 13.23466),
     ),
     laptop: formatNumber(
-      Math.round(((currentEmissions.value - newEmissions.value) * 1000) / 192.62),
+      Math.round((currentEmissions.value - newEmissions.value) / 192.62),
     ),
     email_sent: formatNumber(
-      Math.round(((currentEmissions.value - newEmissions.value) * 1000) / 0.002462),
+      Math.round((currentEmissions.value - newEmissions.value) / 0.002462),
     ),
     visio_hour: formatNumber(
-      Math.round(((currentEmissions.value - newEmissions.value) * 1000) / 0.057063),
+      Math.round((currentEmissions.value - newEmissions.value) / 0.057063),
     ),
   }
 })


### PR DESCRIPTION
The `currentEmissions` values were already given in kgCO2, such that there was no need to multiply them by 1000