### PR TITLE
fix: replace PBF file by area name for LASUR_OSM_SOURCE

### DIFF
--- a/backend/api/config.py
+++ b/backend/api/config.py
@@ -23,7 +23,7 @@ class Config(BaseSettings):
 
     LASUR_API_URL: str = "https://lasur-ws.epfl.ch"
     LASUR_API_KEY: str = ""
-    LASUR_OSM_SOURCE: str = "geneva-greater-area.osm.pbf"
+    LASUR_OSM_SOURCE: str = "geneva"
 
     RATE_LIMIT_USERS_REGISTER: str = "5/minute"
 


### PR DESCRIPTION
The `LASUR_OSM_SOURCE` in the config used to specify the PBF file name, now it defines the region