### PR TITLE
fix(backend): allow varying number of equipment columns in df (#240)

### DIFF
--- a/backend/api/services/stats/equipments.py
+++ b/backend/api/services/stats/equipments.py
@@ -29,7 +29,7 @@ class EquipmentsService(BaseStatsService):
     
     
     def _compute_equipments_reco_matrix(self, df) -> EquipmentRecommendationMatrix:
-        equip_cols = [f"data.equipments.{i}" for i in range(3)]
+        equip_cols = [col for col in df.columns if col.startswith("data.equipments.")]
         rec_cols = [f"typo.reco.reco_dt2.{i}" for i in range(1)]
 
         matrix = EquipmentRecommendationMatrix()


### PR DESCRIPTION
The number of equipment columns can go up to 8, but appears to be dynamic. If users have only given 1-2 equipment, the hard-coded three expected columns will fail

Closes #240 