### PR TITLE
fix(backend): add missing car_passenger in equipment stats

### DIFF
--- a/admin/src/i18n/en/index.ts
+++ b/admin/src/i18n/en/index.ts
@@ -844,6 +844,7 @@ Some environmental impacts have also been calculated:
         moto: 'Motorcycle/scooter',
         car: 'Car',
         car_driver: 'Car (as driver)',
+        car_passenger: 'Car (as passenger)',
         carpool: 'Carpooling',
         plane: 'Plane',
         pub_train: 'Public transport and train',

--- a/admin/src/i18n/fr/index.ts
+++ b/admin/src/i18n/fr/index.ts
@@ -857,6 +857,7 @@ Certains impacts sont aussi calculés :
         moto: 'Moto / scooter',
         car: 'Voiture',
         car_driver: 'Voiture (en tant que conducteur)',
+        car_passenger: 'Voiture (en tant que passager)',
         carpool: 'Covoiturage',
         plane: 'Avion',
         pub_train: 'Transports publics (y compris le train)',

--- a/backend/api/models/query.py
+++ b/backend/api/models/query.py
@@ -277,6 +277,7 @@ class EquipmentPerRecommendation(BaseModel):
     car_driver: int = 0
     ev: int = 0
     inter: int = 0
+    car_passenger: int = 0
 
     total: int = 0
 


### PR DESCRIPTION
The equipment matrix was missing an equipment, `car_passenger`, which was used before October 2025. This commit simply adds it to remove the error.