### PR TITLE
fix(admin): make mode proportions equal

### DIFF
--- a/backend/api/services/stats/emissions.py
+++ b/backend/api/services/stats/emissions.py
@@ -71,7 +71,7 @@ class EmissionsService(BaseStatsService):
             emission.distances = round(emission.distances, 3)
             emission.emissions = round(emission.emissions, 3)
         # filter out emissions with zero emissions
-        results = [e for e in results if e.emissions > 0]
+        results = [e for e in results if e.journeys > 0]
 
         return results
 

--- a/backend/api/services/stats/emissions.py
+++ b/backend/api/services/stats/emissions.py
@@ -672,7 +672,7 @@ class EmissionsService(BaseStatsService):
                     mode=mode_name,
                     total=len(df),
                     distances=float((df_mode['dist_mode'] * df_mode['days'] * 2 * 45).sum()),
-                    journeys=int((df_mode['days'] * 2 * 45).sum()),
+                    journeys=int((df_mode.groupby(['token', 'journey'])['days'].first() * 2 * 45).sum()),
                     emissions=float(df_mode['emissions_dt'].sum())
                 ))
             

--- a/backend/api/services/stats/energy.py
+++ b/backend/api/services/stats/energy.py
@@ -312,7 +312,7 @@ class EnergyService(BaseStatsService):
             
             total_energy = float(df_mode['energy_kcal'].sum())
             total_time = float((df_mode['travel_time'] * df_mode['time_fraction'] * df_mode['days'] * 2 * 45 / 5).sum())
-            total_journeys = int((df_mode['days'] * 2 * 45 / 5).sum())
+            total_journeys = int((df_mode.groupby(['token', 'journey'])['days'].first() * 2 * 45 / 5).sum())
             
             # Calculate average daily kcal per person
             avg_daily = total_energy / len(df) if len(df) > 0 else 0

--- a/backend/tests/test_stats.py
+++ b/backend/tests/test_stats.py
@@ -195,7 +195,8 @@ def test_compute_modes_frequencies():
         Frequencies(field='car', total=30, data=[Frequency(value='1', count=1, sum=1), Frequency(value='2', count=1, sum=2), Frequency(
             value='3', count=1, sum=3), Frequency(value='4', count=3, sum=12), Frequency(value='5', count=3, sum=15)]),
         Frequencies(field='train', total=30, data=[Frequency(value='1', count=1, sum=1), Frequency(
-            value='3', count=2, sum=6), Frequency(value='5', count=1, sum=5)])
+            value='3', count=2, sum=6), Frequency(value='5', count=1, sum=5)]),
+        Frequencies(field='other', total=30, data=[])
     ]
     assert len(result) == len(expected)
     for res_freqs, exp_freqs in zip(result, expected):
@@ -238,7 +239,7 @@ def test_compute_modes_emissions():
     # print(result)
     expected = [
         Emissions(mode='bike', total=30, distances=2693.855,
-                  journeys=2520, emissions=151.304),
+                  journeys=2430, emissions=151.304),
         Emissions(mode='pub', total=30, distances=20522.579,
                   journeys=3690, emissions=2496.472),
         Emissions(mode='moto', total=30, distances=6272.711,


### PR DESCRIPTION
The issue came from intermodal modes being counted multiple times (#0a11d57) and walking no producing emissions and therefore being filtered out (#692ba69). 

Closes #209 