### PR TITLE
feat(backend): add script to generate administrative boundaries

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -140,3 +140,7 @@ cython_debug/
 .vscode/
 
 notebooks/
+
+data/*.pbf
+data/*.gpkg.zip
+data/*/

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -29,6 +29,7 @@ download-world-boundaries:
 
 download-nuts-data:
 	wget -O "data/NUTS_RG_01M_2024_3035.gpkg" "https://gisco-services.ec.europa.eu/distribution/v2/nuts/gpkg/NUTS_RG_01M_2024_3035.gpkg"
+	wget -O "data/NUTS_RG_01M_2021_3035.gpkg" "https://gisco-services.ec.europa.eu/distribution/v2/nuts/gpkg/NUTS_RG_01M_2021_3035.gpkg"
 	wget -O "data/LAU_RG_01M_2024_3035.gpkg" "https://gisco-services.ec.europa.eu/distribution/v2/lau/gpkg/LAU_RG_01M_2024_3035.gpkg"
 
 download-switzerland-osm:

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -23,3 +23,26 @@ db-revision:
 
 seed:
 	curl -X PUT 'http://localhost:8000/seed' -H 'accept: application/json'
+
+download-world-boundaries:
+	wget -O "data/geoBoundariesCGAZ_ADM0.gpkg" "https://github.com/wmgeolab/geoBoundaries/raw/main/releaseData/CGAZ/geoBoundariesCGAZ_ADM0.gpkg"
+
+download-nuts-data:
+	wget -O "data/NUTS_RG_01M_2024_3035.gpkg" "https://gisco-services.ec.europa.eu/distribution/v2/nuts/gpkg/NUTS_RG_01M_2024_3035.gpkg"
+	wget -O "data/LAU_RG_01M_2024_3035.gpkg" "https://gisco-services.ec.europa.eu/distribution/v2/lau/gpkg/LAU_RG_01M_2024_3035.gpkg"
+
+download-switzerland-osm:
+	wget -O "data/switzerland/switzerland.gpkg.zip" "https://download.geofabrik.de/europe/switzerland-latest-free.gpkg.zip"
+	unzip "data/switzerland/switzerland.gpkg.zip" -d data/switzerland/switzerland
+
+download-france-osm:
+	wget -O data/france/franche-comte.gpkg.zip "https://download.geofabrik.de/europe/france/franche-comte-latest-free.gpkg.zip"
+	unzip data/france/franche-comte.gpkg.zip -d data/france/franche-comte
+	wget -O data/france/rhone-alpes.gpkg.zip "https://download.geofabrik.de/europe/france/rhone-alpes-latest-free.gpkg.zip"
+	unzip data/france/rhone-alpes.gpkg.zip -d data/france/rhone-alpes
+
+generate-filtering-boundaries:
+	poetry run python scripts/create_filtering_boundaries.py
+
+generate-multilevel-boundaries:
+	poetry run python scripts/create_multilevel_boundaries.py

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -806,6 +806,35 @@ files = [
 [package.dependencies]
 pydantic = ">=2.0,<3.0"
 
+[package.extras]
+dev = ["bump-my-version", "pre-commit"]
+docs = ["mkdocs", "mkdocs-material", "pygments"]
+test = ["pytest", "pytest-cov", "shapely"]
+
+[[package]]
+name = "geopandas"
+version = "1.1.3"
+description = "Geographic pandas extensions"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "geopandas-1.1.3-py3-none-any.whl", hash = "sha256:90d62a64f95eaa3be2ccc115c5f3d6e24208bb11983b390fdc0621a3eccd0230"},
+    {file = "geopandas-1.1.3.tar.gz", hash = "sha256:91a31989b6f566012838d21d5f8033f37dce882079ccb7cfdc40d5ccce7f284f"},
+]
+
+[package.dependencies]
+numpy = ">=1.24"
+packaging = "*"
+pandas = ">=2.0.0"
+pyogrio = ">=0.7.2"
+pyproj = ">=3.5.0"
+shapely = ">=2.0.0"
+
+[package.extras]
+all = ["GeoAlchemy2", "SQLAlchemy (>=2.0)", "folium", "geopy", "mapclassify (>=2.5)", "matplotlib (>=3.7)", "pointpats (>=2.5.3)", "psycopg[binary] (>=3.1.0)", "pyarrow (>=10.0.0)", "scipy", "xyzservices"]
+dev = ["codecov", "pre-commit", "pytest (>=3.1.0)", "pytest-cov", "pytest-xdist", "ruff"]
+
 [[package]]
 name = "greenlet"
 version = "3.5.0"
@@ -1988,6 +2017,70 @@ files = [
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
+name = "pyogrio"
+version = "0.12.1"
+description = "Vectorized spatial vector file format I/O using GDAL/OGR"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "pyogrio-0.12.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:5c4735235ca0d8dcdb4ecd69bd73e66762d161bce913b10d4458a18137cc7062"},
+    {file = "pyogrio-0.12.1-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:3249d06c2520857b622f3ff0f1b7b4849291ee1fb72f21587825f5fd0f24b787"},
+    {file = "pyogrio-0.12.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f4011b63f9d6c278ee6605971ffabe30b0e8f5992ec2c6df8c70ecfa68a5d02b"},
+    {file = "pyogrio-0.12.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:940857c45051e1e19608ebfe8338bcdf7dd005389057431a3c7b5bff5beb0a5f"},
+    {file = "pyogrio-0.12.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:0fd86bcd69126739325a543a489f312b5fd86db092d2dead682772ae4ee434f3"},
+    {file = "pyogrio-0.12.1-cp310-cp310-win_amd64.whl", hash = "sha256:dcf9cca273ead32beba7c002dd3db8a304105f52dd66200d48fa1ef30d0676af"},
+    {file = "pyogrio-0.12.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:01b322dac2a258d24b024d1028dcaa03c9bb6d9c3988b86d298a64873d10dc65"},
+    {file = "pyogrio-0.12.1-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:e10087abcbd6b7e8212560a7002984e5078ac7b3a969ddc2c9929044dbb0d403"},
+    {file = "pyogrio-0.12.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1f6c621972b09fd81a32317e742c69ff4a7763a803da211361a78317f9577765"},
+    {file = "pyogrio-0.12.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:c38253427b688464caad5316d4ebcec116b5e13f1f02cc4e3588502f136ca1b4"},
+    {file = "pyogrio-0.12.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:5f47787251de7ce13cc06038da93a1214dc283cbccf816be6e03c080358226c8"},
+    {file = "pyogrio-0.12.1-cp311-cp311-win_amd64.whl", hash = "sha256:c1d756cf2da4cdf5609779f260d1e1e89be023184225855d6f3dcd33bbe17cb0"},
+    {file = "pyogrio-0.12.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:7a0d5ca39184030aec4cde30f4258f75b227a854530d2659babc8189d76e657d"},
+    {file = "pyogrio-0.12.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:feaff42bbe8087ca0b30e33b09d1ce049ca55fe83ad83db1139ef37d1d04f30c"},
+    {file = "pyogrio-0.12.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:81096a5139532de5a8003ef02b41d5d2444cb382a9aecd1165b447eb549180d3"},
+    {file = "pyogrio-0.12.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:41b78863f782f7a113ed0d36a5dc74d59735bd3a82af53510899bb02a18b06bb"},
+    {file = "pyogrio-0.12.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:8b65be8c4258b27cc8f919b21929cecdadda4c353e3637fa30850339ef4d15c5"},
+    {file = "pyogrio-0.12.1-cp312-cp312-win_amd64.whl", hash = "sha256:1291b866c2c81d991bda15021b08b3621709b40ee3a85689229929e9465788bf"},
+    {file = "pyogrio-0.12.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:ec0e47a5a704e575092b2fd5c83fa0472a1d421e590f94093eb837bb0a11125d"},
+    {file = "pyogrio-0.12.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:b4c888fc08f388be4dd99dfca5e84a5cdc5994deeec0230cc45144d3460e2b21"},
+    {file = "pyogrio-0.12.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:73a88436f9962750d782853727897ac2722cac5900d920e39fab3e56d7a6a7f1"},
+    {file = "pyogrio-0.12.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:b5d248a0d59fe9bbf9a35690b70004c67830ee0ebe7d4f7bb8ffd8659f684b3a"},
+    {file = "pyogrio-0.12.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:0622bc1a186421547660271083079b38d42e6f868802936d8538c0b379f1ab6b"},
+    {file = "pyogrio-0.12.1-cp313-cp313-win_amd64.whl", hash = "sha256:207bd60c7ffbcea84584596e3637653aa7095e9ee20fa408f90c7f9460392613"},
+    {file = "pyogrio-0.12.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1511b39a283fa27cda906cd187a791578942a87a40b6a06697d9b43bb8ac80b0"},
+    {file = "pyogrio-0.12.1-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:e486cd6aa9ea8a15394a5f84e019d61ec18f257eeeb642348bd68c3d1e57280b"},
+    {file = "pyogrio-0.12.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d3f1a19f63bfd1d3042e45f37ad1d6598123a5a604b6c4ba3f38b419273486cd"},
+    {file = "pyogrio-0.12.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:f3dcc59b3316b8a0f59346bcc638a4d69997864a4d21da839192f50c4c92369a"},
+    {file = "pyogrio-0.12.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:a0643e041dee3e8e038fce69f52a915ecb486e6d7b674c0f9919f3c9e9629689"},
+    {file = "pyogrio-0.12.1-cp313-cp313t-win_amd64.whl", hash = "sha256:5881017f29e110d3613819667657844d8e961b747f2d35cf92f273c27af6d068"},
+    {file = "pyogrio-0.12.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:5a1b0453d1c9e7b03715dd57296c8f3790acb8b50d7e3b5844b3074a18f50709"},
+    {file = "pyogrio-0.12.1-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e7ee560422239dd09ca7f8284cc8483a8919c30d25f3049bb0249bff4c38dec4"},
+    {file = "pyogrio-0.12.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:648c6f7f5f214d30e6cf493b4af1d59782907ac068af9119ca35f18153d6865a"},
+    {file = "pyogrio-0.12.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:58042584f3fd4cabb0f55d26c1405053f656be8a5c266c38140316a1e981aca0"},
+    {file = "pyogrio-0.12.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:b438e38e4ccbaedaa5cb5824ff5de5539315d9b2fde6547c1e816576924ee8ca"},
+    {file = "pyogrio-0.12.1-cp314-cp314-win_amd64.whl", hash = "sha256:f1d8d8a2fea3781dc2a05982c050259261ebc0f6c5e03732d6d79d582adf9363"},
+    {file = "pyogrio-0.12.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:9fe7286946f35a73e6370dc5855bc7a5e8e7babf9e4a8bad7a3279a1d94c7ea9"},
+    {file = "pyogrio-0.12.1-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2c50345b382f1be801d654ec22c70ee974d6057d4ba7afe984b55f2192bc94ee"},
+    {file = "pyogrio-0.12.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0db95765ac0ca935c7fe579e29451294e3ab19c317b0c59c31fbe92a69155e0"},
+    {file = "pyogrio-0.12.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fc882779075982b93064b3bf3d8642514a6df00d9dd752493b104817072cfb01"},
+    {file = "pyogrio-0.12.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:806f620e0c54b54dbdd65e9b6368d24f344cda84c9343364b40a57eb3e1c4dca"},
+    {file = "pyogrio-0.12.1-cp314-cp314t-win_amd64.whl", hash = "sha256:5399f66730978d8852ef5f44dbafa0f738e7f28f4f784349f36830b69a9d2134"},
+    {file = "pyogrio-0.12.1.tar.gz", hash = "sha256:e548ab705bb3e5383693717de1e6c76da97f3762ab92522cb310f93128a75ff1"},
+]
+
+[package.dependencies]
+certifi = "*"
+numpy = "*"
+packaging = "*"
+
+[package.extras]
+benchmark = ["pytest-benchmark"]
+dev = ["cython (>=3.1)"]
+geopandas = ["geopandas"]
+test = ["pytest", "pytest-cov"]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 description = "pyparsing - Classes and methods to define and execute parsing grammars"
@@ -2001,6 +2094,122 @@ files = [
 
 [package.extras]
 diagrams = ["jinja2", "railroad-diagrams"]
+
+[[package]]
+name = "pyproj"
+version = "3.7.1"
+description = "Python interface to PROJ (cartographic projections and coordinate transformations library)"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "python_version == \"3.10\""
+files = [
+    {file = "pyproj-3.7.1-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:bf09dbeb333c34e9c546364e7df1ff40474f9fddf9e70657ecb0e4f670ff0b0e"},
+    {file = "pyproj-3.7.1-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:6575b2e53cc9e3e461ad6f0692a5564b96e7782c28631c7771c668770915e169"},
+    {file = "pyproj-3.7.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8cb516ee35ed57789b46b96080edf4e503fdb62dbb2e3c6581e0d6c83fca014b"},
+    {file = "pyproj-3.7.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e47c4e93b88d99dd118875ee3ca0171932444cdc0b52d493371b5d98d0f30ee"},
+    {file = "pyproj-3.7.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3e8d276caeae34fcbe4813855d0d97b9b825bab8d7a8b86d859c24a6213a5a0d"},
+    {file = "pyproj-3.7.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f173f851ee75e54acdaa053382b6825b400cb2085663a9bb073728a59c60aebb"},
+    {file = "pyproj-3.7.1-cp310-cp310-win32.whl", hash = "sha256:f550281ed6e5ea88fcf04a7c6154e246d5714be495c50c9e8e6b12d3fb63e158"},
+    {file = "pyproj-3.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:3537668992a709a2e7f068069192138618c00d0ba113572fdd5ee5ffde8222f3"},
+    {file = "pyproj-3.7.1-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:a94e26c1a4950cea40116775588a2ca7cf56f1f434ff54ee35a84718f3841a3d"},
+    {file = "pyproj-3.7.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:263b54ba5004b6b957d55757d846fc5081bc02980caa0279c4fc95fa0fff6067"},
+    {file = "pyproj-3.7.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f6d6a2ccd5607cd15ef990c51e6f2dd27ec0a741e72069c387088bba3aab60fa"},
+    {file = "pyproj-3.7.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c5dcf24ede53d8abab7d8a77f69ff1936c6a8843ef4fcc574646e4be66e5739"},
+    {file = "pyproj-3.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3c2e7449840a44ce860d8bea2c6c1c4bc63fa07cba801dcce581d14dcb031a02"},
+    {file = "pyproj-3.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0829865c1d3a3543f918b3919dc601eea572d6091c0dd175e1a054db9c109274"},
+    {file = "pyproj-3.7.1-cp311-cp311-win32.whl", hash = "sha256:6181960b4b812e82e588407fe5c9c68ada267c3b084db078f248db5d7f45d18a"},
+    {file = "pyproj-3.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ad0ff443a785d84e2b380869fdd82e6bfc11eba6057d25b4409a9bbfa867970"},
+    {file = "pyproj-3.7.1-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:2781029d90df7f8d431e29562a3f2d8eafdf233c4010d6fc0381858dc7373217"},
+    {file = "pyproj-3.7.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:d61bf8ab04c73c1da08eedaf21a103b72fa5b0a9b854762905f65ff8b375d394"},
+    {file = "pyproj-3.7.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:04abc517a8555d1b05fcee768db3280143fe42ec39fdd926a2feef31631a1f2f"},
+    {file = "pyproj-3.7.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:084c0a475688f934d386c2ab3b6ce03398a473cd48adfda70d9ab8f87f2394a0"},
+    {file = "pyproj-3.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a20727a23b1e49c7dc7fe3c3df8e56a8a7acdade80ac2f5cca29d7ca5564c145"},
+    {file = "pyproj-3.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bf84d766646f1ebd706d883755df4370aaf02b48187cedaa7e4239f16bc8213d"},
+    {file = "pyproj-3.7.1-cp312-cp312-win32.whl", hash = "sha256:5f0da2711364d7cb9f115b52289d4a9b61e8bca0da57f44a3a9d6fc9bdeb7274"},
+    {file = "pyproj-3.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:aee664a9d806612af30a19dba49e55a7a78ebfec3e9d198f6a6176e1d140ec98"},
+    {file = "pyproj-3.7.1-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:5f8d02ef4431dee414d1753d13fa82a21a2f61494737b5f642ea668d76164d6d"},
+    {file = "pyproj-3.7.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:0b853ae99bda66cbe24b4ccfe26d70601d84375940a47f553413d9df570065e0"},
+    {file = "pyproj-3.7.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83db380c52087f9e9bdd8a527943b2e7324f275881125e39475c4f9277bdeec4"},
+    {file = "pyproj-3.7.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b35ed213892e211a3ce2bea002aa1183e1a2a9b79e51bb3c6b15549a831ae528"},
+    {file = "pyproj-3.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a8b15b0463d1303bab113d1a6af2860a0d79013c3a66fcc5475ce26ef717fd4f"},
+    {file = "pyproj-3.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:87229e42b75e89f4dad6459200f92988c5998dfb093c7c631fb48524c86cd5dc"},
+    {file = "pyproj-3.7.1-cp313-cp313-win32.whl", hash = "sha256:d666c3a3faaf3b1d7fc4a544059c4eab9d06f84a604b070b7aa2f318e227798e"},
+    {file = "pyproj-3.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:d3caac7473be22b6d6e102dde6c46de73b96bc98334e577dfaee9886f102ea2e"},
+    {file = "pyproj-3.7.1.tar.gz", hash = "sha256:60d72facd7b6b79853f19744779abcd3f804c4e0d4fa8815469db20c9f640a47"},
+]
+
+[package.dependencies]
+certifi = "*"
+
+[[package]]
+name = "pyproj"
+version = "3.7.2"
+description = "Python interface to PROJ (cartographic projections and coordinate transformations library)"
+optional = false
+python-versions = ">=3.11"
+groups = ["main"]
+markers = "python_version >= \"3.11\""
+files = [
+    {file = "pyproj-3.7.2-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:2514d61f24c4e0bb9913e2c51487ecdaeca5f8748d8313c933693416ca41d4d5"},
+    {file = "pyproj-3.7.2-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:8693ca3892d82e70de077701ee76dd13d7bca4ae1c9d1e739d72004df015923a"},
+    {file = "pyproj-3.7.2-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:5e26484d80fea56273ed1555abaea161e9661d81a6c07815d54b8e883d4ceb25"},
+    {file = "pyproj-3.7.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:281cb92847814e8018010c48b4069ff858a30236638631c1a91dd7bfa68f8a8a"},
+    {file = "pyproj-3.7.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9c8577f0b7bb09118ec2e57e3babdc977127dd66326d6c5d755c76b063e6d9dc"},
+    {file = "pyproj-3.7.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a23f59904fac3a5e7364b3aa44d288234af267ca041adb2c2b14a903cd5d3ac5"},
+    {file = "pyproj-3.7.2-cp311-cp311-win32.whl", hash = "sha256:f2af4ed34b2cf3e031a2d85b067a3ecbd38df073c567e04b52fa7a0202afde8a"},
+    {file = "pyproj-3.7.2-cp311-cp311-win_amd64.whl", hash = "sha256:0b7cb633565129677b2a183c4d807c727d1c736fcb0568a12299383056e67433"},
+    {file = "pyproj-3.7.2-cp311-cp311-win_arm64.whl", hash = "sha256:38b08d85e3a38e455625b80e9eb9f78027c8e2649a21dec4df1f9c3525460c71"},
+    {file = "pyproj-3.7.2-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:0a9bb26a6356fb5b033433a6d1b4542158fb71e3c51de49b4c318a1dff3aeaab"},
+    {file = "pyproj-3.7.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:567caa03021178861fad27fabde87500ec6d2ee173dd32f3e2d9871e40eebd68"},
+    {file = "pyproj-3.7.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:c203101d1dc3c038a56cff0447acc515dd29d6e14811406ac539c21eed422b2a"},
+    {file = "pyproj-3.7.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:1edc34266c0c23ced85f95a1ee8b47c9035eae6aca5b6b340327250e8e281630"},
+    {file = "pyproj-3.7.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:aa9f26c21bc0e2dc3d224cb1eb4020cf23e76af179a7c66fea49b828611e4260"},
+    {file = "pyproj-3.7.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f9428b318530625cb389b9ddc9c51251e172808a4af79b82809376daaeabe5e9"},
+    {file = "pyproj-3.7.2-cp312-cp312-win32.whl", hash = "sha256:b3d99ed57d319da042f175f4554fc7038aa4bcecc4ac89e217e350346b742c9d"},
+    {file = "pyproj-3.7.2-cp312-cp312-win_amd64.whl", hash = "sha256:11614a054cd86a2ed968a657d00987a86eeb91fdcbd9ad3310478685dc14a128"},
+    {file = "pyproj-3.7.2-cp312-cp312-win_arm64.whl", hash = "sha256:509a146d1398bafe4f53273398c3bb0b4732535065fa995270e52a9d3676bca3"},
+    {file = "pyproj-3.7.2-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:19466e529b1b15eeefdf8ff26b06fa745856c044f2f77bf0edbae94078c1dfa1"},
+    {file = "pyproj-3.7.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:c79b9b84c4a626c5dc324c0d666be0bfcebd99f7538d66e8898c2444221b3da7"},
+    {file = "pyproj-3.7.2-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:ceecf374cacca317bc09e165db38ac548ee3cad07c3609442bd70311c59c21aa"},
+    {file = "pyproj-3.7.2-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5141a538ffdbe4bfd157421828bb2e07123a90a7a2d6f30fa1462abcfb5ce681"},
+    {file = "pyproj-3.7.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f000841e98ea99acbb7b8ca168d67773b0191de95187228a16110245c5d954d5"},
+    {file = "pyproj-3.7.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8115faf2597f281a42ab608ceac346b4eb1383d3b45ab474fd37341c4bf82a67"},
+    {file = "pyproj-3.7.2-cp313-cp313-win32.whl", hash = "sha256:f18c0579dd6be00b970cb1a6719197fceecc407515bab37da0066f0184aafdf3"},
+    {file = "pyproj-3.7.2-cp313-cp313-win_amd64.whl", hash = "sha256:bb41c29d5f60854b1075853fe80c58950b398d4ebb404eb532536ac8d2834ed7"},
+    {file = "pyproj-3.7.2-cp313-cp313-win_arm64.whl", hash = "sha256:2b617d573be4118c11cd96b8891a0b7f65778fa7733ed8ecdb297a447d439100"},
+    {file = "pyproj-3.7.2-cp313-cp313t-macosx_13_0_x86_64.whl", hash = "sha256:d27b48f0e81beeaa2b4d60c516c3a1cfbb0c7ff6ef71256d8e9c07792f735279"},
+    {file = "pyproj-3.7.2-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:55a3610d75023c7b1c6e583e48ef8f62918e85a2ae81300569d9f104d6684bb6"},
+    {file = "pyproj-3.7.2-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:8d7349182fa622696787cc9e195508d2a41a64765da9b8a6bee846702b9e6220"},
+    {file = "pyproj-3.7.2-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:d230b186eb876ed4f29a7c5ee310144c3a0e44e89e55f65fb3607e13f6db337c"},
+    {file = "pyproj-3.7.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:237499c7862c578d0369e2b8ac56eec550e391a025ff70e2af8417139dabb41c"},
+    {file = "pyproj-3.7.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8c225f5978abd506fd9a78eaaf794435e823c9156091cabaab5374efb29d7f69"},
+    {file = "pyproj-3.7.2-cp313-cp313t-win32.whl", hash = "sha256:2da731876d27639ff9d2d81c151f6ab90a1546455fabd93368e753047be344a2"},
+    {file = "pyproj-3.7.2-cp313-cp313t-win_amd64.whl", hash = "sha256:f54d91ae18dd23b6c0ab48126d446820e725419da10617d86a1b69ada6d881d3"},
+    {file = "pyproj-3.7.2-cp313-cp313t-win_arm64.whl", hash = "sha256:fc52ba896cfc3214dc9f9ca3c0677a623e8fdd096b257c14a31e719d21ff3fdd"},
+    {file = "pyproj-3.7.2-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:2aaa328605ace41db050d06bac1adc11f01b71fe95c18661497763116c3a0f02"},
+    {file = "pyproj-3.7.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:35dccbce8201313c596a970fde90e33605248b66272595c061b511c8100ccc08"},
+    {file = "pyproj-3.7.2-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:25b0b7cb0042444c29a164b993c45c1b8013d6c48baa61dc1160d834a277e83b"},
+    {file = "pyproj-3.7.2-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:85def3a6388e9ba51f964619aa002a9d2098e77c6454ff47773bb68871024281"},
+    {file = "pyproj-3.7.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b1bccefec3875ab81eabf49059e2b2ea77362c178b66fd3528c3e4df242f1516"},
+    {file = "pyproj-3.7.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d5371ca114d6990b675247355a801925814eca53e6c4b2f1b5c0a956336ee36e"},
+    {file = "pyproj-3.7.2-cp314-cp314-win32.whl", hash = "sha256:77f066626030f41be543274f5ac79f2a511fe89860ecd0914f22131b40a0ec25"},
+    {file = "pyproj-3.7.2-cp314-cp314-win_amd64.whl", hash = "sha256:5a964da1696b8522806f4276ab04ccfff8f9eb95133a92a25900697609d40112"},
+    {file = "pyproj-3.7.2-cp314-cp314-win_arm64.whl", hash = "sha256:e258ab4dbd3cf627809067c0ba8f9884ea76c8e5999d039fb37a1619c6c3e1f6"},
+    {file = "pyproj-3.7.2-cp314-cp314t-macosx_13_0_x86_64.whl", hash = "sha256:bbbac2f930c6d266f70ec75df35ef851d96fdb3701c674f42fd23a9314573b37"},
+    {file = "pyproj-3.7.2-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:b7544e0a3d6339dc9151e9c8f3ea62a936ab7cc446a806ec448bbe86aebb979b"},
+    {file = "pyproj-3.7.2-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:f7f5133dca4c703e8acadf6f30bc567d39a42c6af321e7f81975c2518f3ed357"},
+    {file = "pyproj-3.7.2-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:5aff3343038d7426aa5076f07feb88065f50e0502d1b0d7c22ddfdd2c75a3f81"},
+    {file = "pyproj-3.7.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:b0552178c61f2ac1c820d087e8ba6e62b29442debddbb09d51c4bf8acc84d888"},
+    {file = "pyproj-3.7.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:47d87db2d2c436c5fd0409b34d70bb6cdb875cca2ebe7a9d1c442367b0ab8d59"},
+    {file = "pyproj-3.7.2-cp314-cp314t-win32.whl", hash = "sha256:c9b6f1d8ad3e80a0ee0903a778b6ece7dca1d1d40f6d114ae01bc8ddbad971aa"},
+    {file = "pyproj-3.7.2-cp314-cp314t-win_amd64.whl", hash = "sha256:1914e29e27933ba6f9822663ee0600f169014a2859f851c054c88cf5ea8a333c"},
+    {file = "pyproj-3.7.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d9d25bae416a24397e0d85739f84d323b55f6511e45a522dd7d7eae70d10c7e4"},
+    {file = "pyproj-3.7.2.tar.gz", hash = "sha256:39a0cf1ecc7e282d1d30f36594ebd55c9fae1fda8a2622cee5d100430628f88c"},
+]
+
+[package.dependencies]
+certifi = "*"
 
 [[package]]
 name = "pytest"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -27,6 +27,7 @@ geojson-pydantic = "^2.1.0"
 shapely = "^2.1.2"
 slowapi = "^0.1.9"
 matplotlib = "^3.10.8"
+geopandas = "^1.1.3"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^9.0.1"

--- a/backend/scripts/create_filtering_boundaries.py
+++ b/backend/scripts/create_filtering_boundaries.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Create district-sized GeoJSON from OSM extracts for participant filtering.
+
+Combines French arrondissements (admin_level7) from Franche-Comte and Rhone-Alpes
+with Swiss districts (admin_level6) and districtless cantons (admin_level4).
+"""
+
+import sys
+from pathlib import Path
+
+import geopandas as gpd
+import pandas as pd
+
+LAYER_NAME = "gis_osm_adminareas_a_free"
+
+DISTRICTLESS_CANTONS: list[str] = [
+    "Uri",
+    "Obwalden",
+    "Nidwalden",
+    "Glarus",
+    "Zug",
+    "Basel-Stadt",
+    "Genève",
+    "Appenzell Innerrhoden",
+    "Appenzell Ausserrhoden",
+    "Luzern",
+    "Neuchâtel",
+]
+
+
+def read_osm_extract(path: Path, layer: str = LAYER_NAME) -> gpd.GeoDataFrame:
+    """Read an OSM administrative areas layer from a GeoPackage."""
+    if not path.exists():
+        print(f"Error: file not found: {path}", file=sys.stderr)
+        sys.exit(1)
+    return gpd.read_file(path, layer=layer)
+
+
+def get_france_arrondissements(france_paths: list[Path]) -> gpd.GeoDataFrame:
+    """Extract admin_level7 (arrondissements) from French OSM extracts."""
+    frames: list[gpd.GeoDataFrame] = []
+    for path in france_paths:
+        gdf = read_osm_extract(path)
+        arrondissements = gdf[gdf.fclass == "admin_level7"]
+        print(f"  {path.name}: {len(arrondissements)} arrondissements")
+        frames.append(arrondissements)
+    return pd.concat(frames, ignore_index=True)
+
+
+def get_switzerland_areas(ch_path: Path) -> gpd.GeoDataFrame:
+    """Extract Swiss districts and districtless cantons from the OSM extract."""
+    gdf = read_osm_extract(ch_path)
+
+    districts = gdf[gdf.fclass == "admin_level6"]
+    print(f"  {ch_path.name}: {len(districts)} districts")
+
+    cantons = gdf[(gdf.fclass == "admin_level4") & (gdf.name.isin(DISTRICTLESS_CANTONS))]
+    print(f"  {ch_path.name}: {len(cantons)} districtless cantons")
+
+    return pd.concat([cantons, districts], ignore_index=True)
+
+
+def main() -> None:
+    """Build the unified administrative boundaries GeoJSON."""
+    base_dir = Path(__file__).resolve().parent.parent
+    data_dir = base_dir / "data"
+
+    france_paths = [
+        data_dir / "france" / "franche-comte" / "franche-comte.gpkg",
+        data_dir / "france" / "rhone-alpes" / "rhone-alpes.gpkg",
+    ]
+
+    ch_path = data_dir / "switzerland" / "switzerland.gpkg"
+
+    print("Loading French arrondissements...")
+    france = get_france_arrondissements(france_paths)
+
+    print("Loading Swiss areas...")
+    switzerland = get_switzerland_areas(ch_path)
+
+    output = pd.concat([france, switzerland], ignore_index=True)
+    output_path = data_dir / "filtering_boundaries.geojson"
+
+    print(f"\nTotal features: {len(output)}")
+    print(f"Writing to {output_path}...")
+    output.to_file(output_path, driver="GeoJSON")
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/create_multilevel_boundaries.py
+++ b/backend/scripts/create_multilevel_boundaries.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+Create unified GeoPackages for local, regional, and national boundaries.
+"""
+
+from pathlib import Path
+
+import geopandas as gpd
+import pandas as pd
+
+def extract_municipalities(
+    nuts_df: gpd.GeoDataFrame, 
+    lau_df: gpd.GeoDataFrame, 
+    country_code: str, 
+    region_name: str) -> gpd.GeoDataFrame:
+    """Extract municipalities (LAU) that intersect with a given NUTS region."""
+    region = nuts_df[(nuts_df["CNTR_CODE"] == country_code) & (nuts_df["NAME_LATN"] == region_name)]
+    region_geometry = region.geometry.iloc[0]
+    municipalities = lau_df[(lau_df.intersects(region_geometry)) & (lau_df["CNTR_CODE"] == country_code)]
+    return municipalities
+
+def get_data_path() -> Path:
+    """Get the path to the data directory."""
+    base_dir = Path(__file__).resolve().parent.parent
+    data_dir = base_dir / "data"
+
+    return data_dir
+
+def extract_local_boundaries(
+    nuts_df: gpd.GeoDataFrame,
+    lau_df: gpd.GeoDataFrame
+) -> gpd.GeoDataFrame:
+    """Extract local boundaries (municipalities) for all countries."""
+    fr_municipalities = extract_local_french_boundaries(nuts_df, lau_df)
+    ch_municipalities = extract_local_swiss_boundaries(lau_df)
+    de_municipalities = extract_local_german_boundaries(nuts_df, lau_df)
+    it_municipalities = extract_local_italian_boundaries(nuts_df, lau_df)
+
+    municipalities = pd.concat([fr_municipalities, ch_municipalities, de_municipalities, it_municipalities], ignore_index=True)
+        
+    municipalities = municipalities[["CNTR_CODE", "LAU_NAME", "geometry"]]
+    municipalities = municipalities.rename(columns={"CNTR_CODE": "country", "LAU_NAME": "name"})
+
+    return municipalities
+
+
+def extract_local_french_boundaries(
+    nuts_df: gpd.GeoDataFrame,
+    lau_df: gpd.GeoDataFrame
+) -> gpd.GeoDataFrame:
+    fr_ara_municipalities = extract_municipalities(nuts_df, lau_df, "FR", "Auvergne-Rhône-Alpes")
+    fr_bfc_municipalities = extract_municipalities(nuts_df, lau_df, "FR", "Bourgogne-Franche-Comté")
+    fr_ge_municipalities = extract_municipalities(nuts_df, lau_df, "FR", "Grand Est")
+
+    fr_municipalities = pd.concat([fr_ara_municipalities, fr_bfc_municipalities, fr_ge_municipalities], ignore_index=True)
+
+    return fr_municipalities
+
+
+def extract_local_swiss_boundaries(
+    lau_df: gpd.GeoDataFrame
+) -> gpd.GeoDataFrame:
+    return lau_df[(lau_df["CNTR_CODE"] == "CH") & (lau_df["POP_2024"] > 0)]
+
+
+def extract_local_german_boundaries(
+    nuts_df: gpd.GeoDataFrame,
+    lau_df: gpd.GeoDataFrame
+) -> gpd.GeoDataFrame:
+    bw_municipalities = extract_municipalities(nuts_df, lau_df, "DE", "Baden-Württemberg")
+
+    return bw_municipalities
+
+def extract_local_italian_boundaries(
+    nuts_df: gpd.GeoDataFrame,
+    lau_df: gpd.GeoDataFrame
+) -> gpd.GeoDataFrame:
+    it_va_municipalities = extract_municipalities(nuts_df, lau_df, "IT", "Valle d’Aosta/Vallée d’Aoste")
+    it_pi_municipalities = extract_municipalities(nuts_df, lau_df, "IT", "Piemonte")
+
+    return pd.concat([it_va_municipalities, it_pi_municipalities], ignore_index=True)
+
+def extract_regional_boundaries(
+    nuts_df: gpd.GeoDataFrame,
+    nuts_2021_df: gpd.GeoDataFrame
+) -> gpd.GeoDataFrame:
+    # Configure exclusions here
+    EXCLUDED_NUTS3_IDS = {"FRY10", "FRY20", "FRY30", "FRY40", "FRY50"}  # FR overseas departments
+    EXCLUDED_NUTS2_IDS = {"ES70", "PT20", "PT30"}  # Canarias, Açores, Madeira
+
+    # Optional extra exclusions by display name
+    EXCLUDED_NUTS3_NAMES = {"Guadeloupe", "Guyane", "La Réunion", "Mayotte", "Martinique"}
+    EXCLUDED_NUTS2_NAMES = {"Canarias", "Açores", "Madeira"}
+
+    nuts_clean = nuts_df.assign(NAME_LATN_CLEAN=nuts_df["NAME_LATN"].fillna("").str.strip())
+
+    nuts3 = nuts_clean[(nuts_clean["LEVL_CODE"] == 3) & (nuts_clean["CNTR_CODE"].isin(["FR", "CH"]))]
+    nuts3 = nuts3[
+        (~nuts3["NUTS_ID"].isin(EXCLUDED_NUTS3_IDS))
+        & (~nuts3["NAME_LATN_CLEAN"].isin(EXCLUDED_NUTS3_NAMES))
+    ]
+
+    nuts2 = nuts_clean[(nuts_clean["LEVL_CODE"] == 2) & (~nuts_clean["CNTR_CODE"].isin(["FR", "CH"]))]
+    nuts2 = nuts2[
+        (~nuts2["NUTS_ID"].isin(EXCLUDED_NUTS2_IDS))
+        & (~nuts2["NAME_LATN_CLEAN"].isin(EXCLUDED_NUTS2_NAMES))
+    ]
+
+    regions = pd.concat([nuts3, nuts2], ignore_index=True).drop(columns=["NAME_LATN_CLEAN"], errors="ignore")
+
+    uk_nuts = nuts_2021_df[(nuts_2021_df["CNTR_CODE"] == "UK") & (nuts_2021_df["LEVL_CODE"] == 2)]
+    regions = pd.concat([regions, uk_nuts], ignore_index=True)
+
+    regions = regions[["CNTR_CODE", "NAME_LATN", "geometry"]]
+    # rename columns to "country, name, geometry"
+    regions = regions.rename(columns={"CNTR_CODE": "country", "NAME_LATN": "name"})
+
+    return regions
+
+def extract_national_boundaries(gbd_df: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    nations = gbd_df[["shapeType", "shapeName", "geometry"]]
+    # rename columns to "type, name, geometry"
+    nations = nations.rename(columns={"shapeType": "type", "shapeName": "name"})
+
+    return nations
+
+
+def main() -> None:
+    data_dir = get_data_path()
+    nuts_df = gpd.read_file(data_dir / "NUTS_RG_01M_2024_3035.gpkg")
+    nuts_2021_df = gpd.read_file(data_dir / "NUTS_RG_01M_2021_3035.gpkg")
+    lau_df = gpd.read_file(data_dir / "LAU_RG_01M_2024_3035.gpkg")
+    gbd_df = gpd.read_file(data_dir / "geoBoundariesCGAZ_ADM0.gpkg")
+
+    print("Extracting local boundaries...")
+    local_boundaries = extract_local_boundaries(nuts_df, lau_df)
+    local_boundaries.to_file(data_dir / "local_boundaries.geojson", driver="GeoJSON")
+    
+    print("Extracting regional boundaries...")
+    regional_boundaries = extract_regional_boundaries(nuts_df, nuts_2021_df)
+    regional_boundaries.to_file(data_dir / "regional_boundaries.geojson", driver="GeoJSON")
+
+    print("Extracting national boundaries...")
+    national_boundaries = extract_national_boundaries(gbd_df)
+    national_boundaries.to_file(data_dir / "national_boundaries.geojson", driver="GeoJSON")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR introduces two scripts to extract the administrative boundaries necessary for two features:
* the filtering of participant data based on district level (France, Switzerland) (#210)
* the replacement of agnostic h3 hexagons by administrative boundaries at three different levels (local, regional, national) (#278)

The PR adds several targets to the backend `Makefile` to download and process the data.

# District level

<img width="506" height="413" alt="image" src="https://github.com/user-attachments/assets/c1f689d5-af24-485e-8c9e-a7ff25226754" />

# Multi-level boundaries

## National

<img width="833" height="418" alt="image" src="https://github.com/user-attachments/assets/893020ba-b77e-4791-b647-a0cf0a081582" />

## Regional

<img width="755" height="847" alt="image" src="https://github.com/user-attachments/assets/d4ede851-0b15-4984-b70d-24965202e28b" />

## Local

<img width="798" height="847" alt="image" src="https://github.com/user-attachments/assets/2aa2432c-f54b-487c-9522-6877cc805e8e" />
