### PR TITLE
feat: per-chart percent toggle, synced with report preview

### DIFF
--- a/admin/src/components/DashboardPanel.vue
+++ b/admin/src/components/DashboardPanel.vue
@@ -75,9 +75,6 @@
         <q-btn icon="settings" size="sm" color="field" outline>
           <q-menu>
             <q-list style="min-width: 100px">
-              <q-item>
-                <q-checkbox v-model="percent" :label="t('stats.percent_employees')" />
-              </q-item>
               <q-item class="q-mb-md q-mr-sm">
                 <div style="width: 200px">
                   <div>{{ t('stats.charts_height') }}</div>
@@ -109,11 +106,7 @@
       </div>
     </div>
     <div v-else>
-      <charts-panel
-        :percent="percent"
-        :height="height"
-        :collaborators-count="totalCollaboratorsCount"
-      />
+      <charts-panel :height="height" :collaborators-count="totalCollaboratorsCount" />
     </div>
     <area-dialog
       v-model="showMapFilter"
@@ -137,7 +130,6 @@ const services = useServices()
 const companyService = services.make('company')
 const campaignService = services.make('campaign')
 
-const percent = ref(true)
 const height = ref(400)
 const companyMap = ref<{ [key: string]: Company }>({})
 const campaignMap = ref<{ [key: string]: Campaign }>({})
@@ -277,6 +269,13 @@ async function goToReport() {
   url.searchParams.set('emModalType', stats.emModalType)
   url.searchParams.set('redModalType', stats.redModalType)
   url.searchParams.set('redShareModalType', stats.redShareModalType)
+
+  url.searchParams.set('travelTimePercent', String(stats.travelTimePercent))
+  url.searchParams.set('equipmentsPercent', String(stats.equipmentsPercent))
+  url.searchParams.set('constraintsPercent', String(stats.constraintsPercent))
+  url.searchParams.set('freqModProPercent', String(stats.freqModProPercent))
+  url.searchParams.set('leversPercent', String(stats.leversPercent))
+  url.searchParams.set('motivationPercent', String(stats.motivationPercent))
 
   window.open(url.toString(), '_blank')
 }

--- a/admin/src/components/charts/ChartsPanel.vue
+++ b/admin/src/components/charts/ChartsPanel.vue
@@ -43,19 +43,16 @@
             :frequencies="getFreq('travel_time')"
             :xaxis="t('stats.travel_time.xaxis')"
             :range-step="5"
-            :percent="percent"
             :height="height"
             :loading="stats.loading"
           />
           <equipment-frequencies-chart
             :frequencies="getFreq('equipments')"
-            :percent="percent"
             :height="height"
             :loading="stats.loading"
           />
           <mobility-constraints-frequencies-chart
             :frequencies="getFreq('constraints')"
-            :percent="percent"
             :height="height"
             :loading="stats.loading"
           />
@@ -77,7 +74,6 @@
           <freq-mod-pro-chart
             :frequencies="getFreqArray('freq_mod_pro')"
             :height="height"
-            :percent="percent"
             :loading="stats.loading"
           />
           <emissions-mod-pro-chart
@@ -161,13 +157,11 @@
             :behavior-change-stats="stats.behaviorChange"
             :height="height"
             :loading="stats.loading"
-            :percent="percent"
           />
           <motivation-change-chart
             :behavior-change-stats="stats.behaviorChange"
             :height="height"
             :loading="stats.loading"
-            :percent="percent"
           />
           <equipment-recommendation-matrix-chart
             class="grid-item-full-row"
@@ -207,7 +201,6 @@ import type { Frequencies } from 'src/models'
 
 interface Props {
   height: number
-  percent: boolean
   collaboratorsCount?: number | undefined
 }
 

--- a/admin/src/components/charts/EquipmentFrequenciesChart.vue
+++ b/admin/src/components/charts/EquipmentFrequenciesChart.vue
@@ -9,6 +9,14 @@
       <q-btn flat icon="more_vert">
         <q-menu>
           <q-list style="min-width: 200px">
+            <q-item clickable v-close-popup @click="onTogglePercent">
+              <q-item-section side>
+                <q-icon :name="stats.equipmentsPercent ? 'check_box' : 'check_box_outline_blank'" />
+              </q-item-section>
+              <q-item-section>
+                <q-item-label>{{ t('stats.percent_employees') }}</q-item-label>
+              </q-item-section>
+            </q-item>
             <q-item clickable v-close-popup @click="onChartDownload">
               <q-item-section side>
                 <q-icon name="download" />
@@ -26,7 +34,7 @@
       :height="height"
       :loading="props.loading"
       :has-data="hasData"
-      :show-info="!!props.percent"
+      :show-info="stats.equipmentsPercent"
       :no-data-title="t('stats.equipments.title')"
       :option="option"
       :exportable="!!exportable"
@@ -67,7 +75,6 @@ interface Props {
   loading?: boolean
   xaxis?: string
   yaxis?: string
-  percent?: boolean
   height?: number
   exportable?: boolean
   inline?: boolean
@@ -85,6 +92,12 @@ const shellRef = useTemplateRef<EChartsShellExposed>('shellRef')
 
 function onChartDownload() {
   shellRef.value?.handleExport()
+}
+
+const stats = useStats()
+
+function onTogglePercent() {
+  stats.equipmentsPercent = !stats.equipmentsPercent
 }
 
 const option = ref<EChartsOption>({})
@@ -106,7 +119,7 @@ watch(
   },
 )
 
-watch([() => props.percent, () => props.height, locale], () => {
+watch([() => stats.equipmentsPercent, () => props.height, locale], () => {
   if (!props.loading) {
     initChartOptions()
   }
@@ -154,14 +167,16 @@ function initLabelsChartOptions(frequencies: Frequencies) {
     .map((item) => ({
       key: item.value || 'null',
       name: keyLabel(item.value || 'null'),
-      value: props.percent ? Number(((item.count / total.value) * 100).toFixed(2)) : item.count,
+      value: stats.equipmentsPercent
+        ? Number(((item.count / total.value) * 100).toFixed(2))
+        : item.count,
     }))
     .reverse()
 
   const categories = dataset.map((item) => item.name)
   const values = dataset.map((item) => item.value)
 
-  const mrmtValues = props.percent
+  const mrmtValues = stats.equipmentsPercent
     ? dataset.map((item) => {
         const mrmt = MRMT_VALUES_PERCENT[item.key as keyof typeof MRMT_VALUES_PERCENT]
         return mrmt ?? null
@@ -183,7 +198,7 @@ function initLabelsChartOptions(frequencies: Frequencies) {
       data: values,
     },
   ]
-  if (props.percent) {
+  if (stats.equipmentsPercent) {
     series.push({
       name: t('stats.reference_data'),
       type: 'pictorialBar',
@@ -239,7 +254,9 @@ function initLabelsChartOptions(frequencies: Frequencies) {
       data: categories,
     },
     xAxis: {
-      name: props.xaxis || (props.percent ? t('stats.percent_employees') : t('stats.nb_employees')),
+      name:
+        props.xaxis ||
+        (stats.equipmentsPercent ? t('stats.percent_employees') : t('stats.nb_employees')),
       nameLocation: 'middle',
       nameGap: 25,
       type: 'value',

--- a/admin/src/components/charts/FreqModProChart.vue
+++ b/admin/src/components/charts/FreqModProChart.vue
@@ -9,6 +9,14 @@
       <q-btn flat icon="more_vert">
         <q-menu>
           <q-list style="min-width: 200px">
+            <q-item clickable v-close-popup @click="onTogglePercent">
+              <q-item-section side>
+                <q-icon :name="stats.freqModProPercent ? 'check_box' : 'check_box_outline_blank'" />
+              </q-item-section>
+              <q-item-section>
+                <q-item-label>{{ t('stats.percent_employees') }}</q-item-label>
+              </q-item-section>
+            </q-item>
             <q-item clickable v-close-popup @click="onChartDownload">
               <q-item-section side>
                 <q-icon name="download" />
@@ -28,7 +36,7 @@
       :groups="['local', 'national', 'europe', 'inter']"
       :xaxis="t('stats.freq_mod_pro.xaxis')"
       :height="height"
-      :percent="percent"
+      :percent="stats.freqModProPercent"
       :loading="loading"
       :exportable="!inline"
     />
@@ -42,7 +50,6 @@ import type { Frequencies } from 'src/models'
 
 interface Props {
   height: number
-  percent: boolean
   loading?: boolean
   frequencies: Frequencies[] | null
   inline?: boolean
@@ -57,6 +64,12 @@ type FrequenciesStackChartExposed = {
 const chartRef = useTemplateRef<FrequenciesStackChartExposed>('chartRef')
 
 const { t } = useI18n()
+
+const stats = useStats()
+
+function onTogglePercent() {
+  stats.freqModProPercent = !stats.freqModProPercent
+}
 
 function onChartDownload() {
   chartRef.value?.handleExport()

--- a/admin/src/components/charts/LeversChangeChart.vue
+++ b/admin/src/components/charts/LeversChangeChart.vue
@@ -9,6 +9,14 @@
       <q-btn flat icon="more_vert">
         <q-menu>
           <q-list style="min-width: 200px">
+            <q-item clickable v-close-popup @click="onTogglePercent">
+              <q-item-section side>
+                <q-icon :name="stats.leversPercent ? 'check_box' : 'check_box_outline_blank'" />
+              </q-item-section>
+              <q-item-section>
+                <q-item-label>{{ t('stats.percent_employees') }}</q-item-label>
+              </q-item-section>
+            </q-item>
             <q-item clickable v-close-popup @click="onChartDownload">
               <q-item-section side>
                 <q-icon name="download" />
@@ -27,7 +35,7 @@
       :behavior-change-stats="behaviorChangeStats"
       :height="height"
       :loading="loading"
-      :percent="percent"
+      :percent="stats.leversPercent"
       :exportable="!inline"
       :description="chartDescription"
     />
@@ -42,7 +50,6 @@ import type { BehaviorChangeStats } from 'src/models'
 
 interface Props {
   height: number
-  percent: boolean
   loading?: boolean
   behaviorChangeStats: BehaviorChangeStats | null
   inline?: boolean
@@ -57,6 +64,12 @@ type BehaviorChangeChartExposed = {
 const chartRef = useTemplateRef<BehaviorChangeChartExposed>('chartRef')
 
 const { t } = useI18n()
+
+const stats = useStats()
+
+function onTogglePercent() {
+  stats.leversPercent = !stats.leversPercent
+}
 
 function onChartDownload() {
   chartRef.value?.handleExport()

--- a/admin/src/components/charts/MobilityConstraintsFrequenciesChart.vue
+++ b/admin/src/components/charts/MobilityConstraintsFrequenciesChart.vue
@@ -9,6 +9,16 @@
       <q-btn flat icon="more_vert">
         <q-menu>
           <q-list style="min-width: 200px">
+            <q-item clickable v-close-popup @click="onTogglePercent">
+              <q-item-section side>
+                <q-icon
+                  :name="stats.constraintsPercent ? 'check_box' : 'check_box_outline_blank'"
+                />
+              </q-item-section>
+              <q-item-section>
+                <q-item-label>{{ t('stats.percent_employees') }}</q-item-label>
+              </q-item-section>
+            </q-item>
             <q-item clickable v-close-popup @click="onChartDownload">
               <q-item-section side>
                 <q-icon name="download" />
@@ -61,7 +71,6 @@ interface Props {
   xaxis?: string
   yaxis?: string
   rangeStep?: number
-  percent?: boolean
   height?: number
   loading?: boolean
   exportable?: boolean
@@ -80,6 +89,12 @@ const shellRef = useTemplateRef<EChartsShellExposed>('shellRef')
 
 function onChartDownload() {
   shellRef.value?.handleExport()
+}
+
+const stats = useStats()
+
+function onTogglePercent() {
+  stats.constraintsPercent = !stats.constraintsPercent
 }
 
 const option = ref<EChartsOption>({})
@@ -105,7 +120,7 @@ watch(
   },
 )
 
-watch([() => props.percent, () => props.height, locale], () => {
+watch([() => stats.constraintsPercent, () => props.height, locale], () => {
   if (!props.loading) {
     initChartOptions()
   }
@@ -159,7 +174,11 @@ function initValuesChartOptions(frequencies: Frequencies) {
   const values =
     categories?.map((category) => {
       const item = frequencies.data.find((item) => item.value === `${category}`)
-      return item ? (props.percent ? ((item.count / total.value) * 100).toFixed(2) : item.count) : 0
+      return item
+        ? stats.constraintsPercent
+          ? ((item.count / total.value) * 100).toFixed(2)
+          : item.count
+        : 0
     }) || []
 
   const newOption: EChartsOption = {
@@ -184,7 +203,7 @@ function initValuesChartOptions(frequencies: Frequencies) {
     },
     tooltip: {
       trigger: 'item',
-      formatter: `${props.xaxis ? `${props.xaxis}: ` : ''}<b>{b}</b><br/>{c} ${props.percent ? '%' : ''}`,
+      formatter: `${props.xaxis ? `${props.xaxis}: ` : ''}<b>{b}</b><br/>{c} ${stats.constraintsPercent ? '%' : ''}`,
     },
     legend: {
       show: false,
@@ -197,7 +216,9 @@ function initValuesChartOptions(frequencies: Frequencies) {
       data: categories,
     },
     yAxis: {
-      name: props.yaxis || (props.percent ? t('stats.percent_employees') : t('stats.nb_employees')),
+      name:
+        props.yaxis ||
+        (stats.constraintsPercent ? t('stats.percent_employees') : t('stats.nb_employees')),
       nameLocation: 'middle',
       nameGap: 30,
       type: 'value',
@@ -218,7 +239,7 @@ function initLabelsChartOptions(frequencies: Frequencies) {
   const dataset = frequencies.data.map((item) => ({
     key: item.value || 'null',
     name: keyLabel(item.value || 'null'),
-    value: props.percent ? ((item.count / total.value) * 100).toFixed(2) : item.count,
+    value: stats.constraintsPercent ? ((item.count / total.value) * 100).toFixed(2) : item.count,
   }))
 
   // Extract category names and values for yAxis and series
@@ -251,7 +272,7 @@ function initLabelsChartOptions(frequencies: Frequencies) {
     },
     tooltip: {
       trigger: 'item',
-      formatter: `<b>{b}</b><br/>{c} ${props.percent ? '%' : ''}`,
+      formatter: `<b>{b}</b><br/>{c} ${stats.constraintsPercent ? '%' : ''}`,
     },
     legend: {
       show: false,
@@ -264,7 +285,9 @@ function initLabelsChartOptions(frequencies: Frequencies) {
       data: categories,
     },
     xAxis: {
-      name: props.xaxis || (props.percent ? t('stats.percent_employees') : t('stats.nb_employees')),
+      name:
+        props.xaxis ||
+        (stats.constraintsPercent ? t('stats.percent_employees') : t('stats.nb_employees')),
       nameLocation: 'middle',
       nameGap: 30,
       type: 'value',

--- a/admin/src/components/charts/MotivationChangeChart.vue
+++ b/admin/src/components/charts/MotivationChangeChart.vue
@@ -9,6 +9,14 @@
       <q-btn flat icon="more_vert">
         <q-menu>
           <q-list style="min-width: 200px">
+            <q-item clickable v-close-popup @click="onTogglePercent">
+              <q-item-section side>
+                <q-icon :name="stats.motivationPercent ? 'check_box' : 'check_box_outline_blank'" />
+              </q-item-section>
+              <q-item-section>
+                <q-item-label>{{ t('stats.percent_employees') }}</q-item-label>
+              </q-item-section>
+            </q-item>
             <q-item clickable v-close-popup @click="onChartDownload">
               <q-item-section side>
                 <q-icon name="download" />
@@ -27,7 +35,7 @@
       :behavior-change-stats="behaviorChangeStats"
       :height="height"
       :loading="loading"
-      :percent="percent"
+      :percent="stats.motivationPercent"
       :exportable="!inline"
       :description="chartDescription"
     />
@@ -42,7 +50,6 @@ import type { BehaviorChangeStats } from 'src/models'
 
 interface Props {
   height: number
-  percent: boolean
   loading?: boolean
   behaviorChangeStats: BehaviorChangeStats | null
   inline?: boolean
@@ -57,6 +64,12 @@ type BehaviorChangeChartExposed = {
 const chartRef = useTemplateRef<BehaviorChangeChartExposed>('chartRef')
 
 const { t } = useI18n()
+
+const stats = useStats()
+
+function onTogglePercent() {
+  stats.motivationPercent = !stats.motivationPercent
+}
 
 function onChartDownload() {
   chartRef.value?.handleExport()

--- a/admin/src/components/charts/TravelTimeFrequenciesChart.vue
+++ b/admin/src/components/charts/TravelTimeFrequenciesChart.vue
@@ -9,6 +9,14 @@
       <q-btn flat icon="more_vert">
         <q-menu>
           <q-list style="min-width: 200px">
+            <q-item clickable v-close-popup @click="onTogglePercent">
+              <q-item-section side>
+                <q-icon :name="stats.travelTimePercent ? 'check_box' : 'check_box_outline_blank'" />
+              </q-item-section>
+              <q-item-section>
+                <q-item-label>{{ t('stats.percent_employees') }}</q-item-label>
+              </q-item-section>
+            </q-item>
             <q-item clickable v-close-popup @click="onChartDownload">
               <q-item-section side>
                 <q-icon name="download" />
@@ -63,7 +71,6 @@ interface Props {
   xaxis?: string
   yaxis?: string
   rangeStep?: number
-  percent?: boolean
   height?: number
   exportable?: boolean
   inline?: boolean
@@ -81,6 +88,12 @@ const shellRef = useTemplateRef<EChartsShellExposed>('shellRef')
 
 function onChartDownload() {
   shellRef.value?.handleExport()
+}
+
+const stats = useStats()
+
+function onTogglePercent() {
+  stats.travelTimePercent = !stats.travelTimePercent
 }
 
 const option = ref<EChartsOption>({})
@@ -103,7 +116,7 @@ watch(
   },
 )
 
-watch([() => props.percent, () => props.height, locale], () => {
+watch([() => stats.travelTimePercent, () => props.height, locale], () => {
   if (!props.loading) {
     initChartOptions()
   }
@@ -186,7 +199,11 @@ function initValuesChartOptions(frequencies: Frequencies) {
   const values =
     categories?.map((category) => {
       const item = frequencies.data.find((item) => item.value === `${category}`)
-      return item ? (props.percent ? ((item.count / total.value) * 100).toFixed(2) : item.count) : 0
+      return item
+        ? stats.travelTimePercent
+          ? ((item.count / total.value) * 100).toFixed(2)
+          : item.count
+        : 0
     }) || []
 
   const newOption: EChartsOption = {
@@ -211,7 +228,7 @@ function initValuesChartOptions(frequencies: Frequencies) {
     },
     tooltip: {
       trigger: 'item',
-      formatter: `${props.xaxis ? `${props.xaxis}: ` : ''}<b>{b}</b><br/>{c} ${props.percent ? '%' : ''}`,
+      formatter: `${props.xaxis ? `${props.xaxis}: ` : ''}<b>{b}</b><br/>{c} ${stats.travelTimePercent ? '%' : ''}`,
     },
     legend: {
       show: false,
@@ -224,7 +241,9 @@ function initValuesChartOptions(frequencies: Frequencies) {
       data: categories,
     },
     yAxis: {
-      name: props.yaxis || (props.percent ? t('stats.percent_employees') : t('stats.nb_employees')),
+      name:
+        props.yaxis ||
+        (stats.travelTimePercent ? t('stats.percent_employees') : t('stats.nb_employees')),
       nameLocation: 'middle',
       nameGap: 30,
       type: 'value',

--- a/admin/src/pages/ReportPreviewPage.vue
+++ b/admin/src/pages/ReportPreviewPage.vue
@@ -54,7 +54,6 @@
           :frequencies="getFreq('travel_time')"
           :xaxis="t('stats.travel_time.xaxis')"
           :range-step="5"
-          :percent="percent"
           :height="height"
           :exportable="false"
           inline
@@ -64,7 +63,6 @@
       <report-page :org-names="orgs">
         <equipment-frequencies-chart
           :frequencies="getFreq('equipments')"
-          :percent="percent"
           :height="height"
           :exportable="false"
           inline
@@ -74,7 +72,6 @@
       <report-page :org-names="orgs">
         <mobility-constraints-frequencies-chart
           :frequencies="getFreq('constraints')"
-          :percent="percent"
           :height="height"
           :exportable="false"
           inline
@@ -104,12 +101,7 @@
         <h2 class="text-h6 q-mt-xl q-mb-md">
           {{ t('stats.sections.professional_travel') }}
         </h2>
-        <freq-mod-pro-chart
-          :frequencies="getFreqArray('freq_mod_pro')"
-          :height="height"
-          :percent="percent"
-          inline
-        />
+        <freq-mod-pro-chart :frequencies="getFreqArray('freq_mod_pro')" :height="height" inline />
       </report-page>
 
       <report-page :org-names="orgs">
@@ -195,7 +187,6 @@
         <levers-change-chart
           :height="height"
           :behavior-change-stats="stats.behaviorChange"
-          :percent="percent"
           inline
         />
       </report-page>
@@ -204,7 +195,6 @@
         <motivation-change-chart
           :height="height"
           :behavior-change-stats="stats.behaviorChange"
-          :percent="percent"
           inline
         />
       </report-page>
@@ -267,12 +257,10 @@ import type { Frequencies } from 'src/models'
 
 interface Props {
   height: number
-  percent: boolean
 }
 
 withDefaults(defineProps<Props>(), {
   height: 400,
-  percent: true,
 })
 
 const { t, locale } = useI18n()
@@ -290,6 +278,13 @@ onMounted(() => {
   statsStore.emModalType = (route.query.emModalType as string) || 'simple'
   statsStore.redModalType = (route.query.redModalType as string) || 'simple'
   statsStore.redShareModalType = (route.query.redShareModalType as string) || 'simple'
+
+  statsStore.travelTimePercent = route.query.travelTimePercent !== 'false'
+  statsStore.equipmentsPercent = route.query.equipmentsPercent !== 'false'
+  statsStore.constraintsPercent = route.query.constraintsPercent !== 'false'
+  statsStore.freqModProPercent = route.query.freqModProPercent !== 'false'
+  statsStore.leversPercent = route.query.leversPercent !== 'false'
+  statsStore.motivationPercent = route.query.motivationPercent !== 'false'
 
   // EmissionsReductionsModChart/EmissionsReductionsModShareChart read these directly from the store
   if (stats.value) {

--- a/admin/src/stores/stats.ts
+++ b/admin/src/stores/stats.ts
@@ -51,6 +51,13 @@ export const useStats = defineStore('stats', () => {
   const redModalType = ref('simple')
   const redShareModalType = ref('simple')
 
+  const travelTimePercent = ref(true)
+  const equipmentsPercent = ref(true)
+  const constraintsPercent = ref(true)
+  const freqModProPercent = ref(true)
+  const leversPercent = ref(true)
+  const motivationPercent = ref(true)
+
   const loading = ref(false)
 
   async function loadStats(filter: Filter | undefined = undefined) {
@@ -184,6 +191,12 @@ export const useStats = defineStore('stats', () => {
     emModalType,
     redModalType,
     redShareModalType,
+    travelTimePercent,
+    equipmentsPercent,
+    constraintsPercent,
+    freqModProPercent,
+    leversPercent,
+    motivationPercent,
     loading,
     loadStats,
     getCampaignStats,


### PR DESCRIPTION
Move the "show as percent" setting out of a single global toggle into each chart's own toolbar, backed by per-chart fields in the stats store (mirroring freqModalType). The chosen settings are now carried through the report preview URL, like the other modal-type toggles, so generated reports render charts with the same percent/count display the user configured in the dashboard.

Relates to #341 